### PR TITLE
Fix player count calculation during csv export

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ function playerName(i) {
 function downloadCsv() {
   // Pivot results into a table that's easier to work with
   const roundNames = lastResults.rounds.map((_, i) => `Round ${i + 1}`)
-  const playerCount = lastResults.rounds.length * lastResults.rounds[0][0].length
+  const playerCount = lastResults.rounds[0].length * lastResults.rounds[0][0].length
   
   // Stub out a row for each player
   const players = []


### PR DESCRIPTION
The player count should be: (number of groups) * (group size)
Before this change, it was: (number of rounds) * (group size)

This would only manifest as an error if the number of rounds was less than the number of groups.
In my case, I was trying to export for 14 groups, 8 people, 8 rounds; an error appears on line 174 once the playerIndex exceeds the size of the pre-allocated array (in this case, 64).